### PR TITLE
Improve API validation, filename sanitization, timeouts, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,45 @@ This FastAPI application allows for easy processing of YAML and CSV files to gen
 ## API Endpoints
 
 ### POST `/generate-r2rml/`
-### POST `/load_gdb/`
-### POST `/rdf_generation/`
+- **Expected Data**:
+  - `yarrrml_file`: A YARRRML file (extension .yaml or .yml).
 
-
-.
-
-- **Expected Data**: 
-  - `file`: A YAML file (extension .yaml or .yml).
-  
 #### Example using `curl`:
 
 ```bash
-curl -X 'POST' 'http://localhost:8000/process-yaml/' -H 'Content-Type: multipart/form-data' -F 'file=@path_to_your_yaml_file.yaml'
+curl -X 'POST' 'http://localhost:8000/generate-r2rml/' \\
+  -H 'Content-Type: multipart/form-data' \\
+  -F 'yarrrml_file=@path_to_your_yaml_file.yaml'
+```
+
+### POST `/load_gdb/`
+- **Expected Data**:
+  - `graph_address`: GraphDB base URL (e.g., http://localhost:7200).
+  - `repo_name`: GraphDB repository name.
+  - `file_name`: File name located in the transfer directory.
+
+#### Example using `curl`:
+
+```bash
+curl -X 'POST' 'http://localhost:8000/load_gdb/' \\
+  -F 'graph_address=http://localhost:7200' \\
+  -F 'repo_name=my_repo' \\
+  -F 'file_name=output.ttl'
+```
+
+### POST `/rdf_generation/`
+- **Expected Data**:
+  - `file_config`: Mapping configuration file (.yaml/.yml or .ttl).
+  - `data_tabular`: CSV file (required when `DB=false`).
+  - `DB`: Boolean flag to use DB mode.
+  - `db_str`: Database connection string (required when `DB=true`).
+
+#### Example using `curl`:
+
+```bash
+curl -X 'POST' 'http://localhost:8000/rdf_generation/' \\
+  -H 'Content-Type: multipart/form-data' \\
+  -F 'file_config=@path_to_config.yaml' \\
+  -F 'data_tabular=@path_to_data.csv' \\
+  -F 'DB=false'
+```

--- a/testyarml/src/config/Initialization.py
+++ b/testyarml/src/config/Initialization.py
@@ -27,8 +27,8 @@ def check_format_config_yaml(yaml_config):
     """
     logging.info(f"Filename is {yaml_config.filename}")
     if (not yaml_config.filename.endswith('.yaml') and not yaml_config.filename.endswith('.yml')) and \
-            (not yaml_config.filename.endswith('.ttl') and not yaml_config.filename.endswith('.ttl')):
-        raise HTTPException(status_code=400, detail="Invalid file type. Only .yaml or .ttl files are accepted.")
+            (not yaml_config.filename.endswith('.ttl')):
+        raise HTTPException(status_code=400, detail="Invalid file type. Only .yaml, .yml, or .ttl files are accepted.")
 
 
 async def data_check_format_init(data):
@@ -45,12 +45,11 @@ def check_format_save_file(file):
     :return:
     """
     logging.info(f"File is {file}")
-    if file.filename.endswith('.yaml'):
-        return f"{PATH_MAPPING}mapping.yaml","yml"
-    elif file.filename.endswith('.ttl'):
-        return f"{PATH_MAPPING}mapping.ttl","ttl"
-    else:
-        raise Exception("File type not supported")
+    if file.filename.endswith('.yaml') or file.filename.endswith('.yml'):
+        return f"{PATH_MAPPING}mapping.yaml", "yml"
+    if file.filename.endswith('.ttl'):
+        return f"{PATH_MAPPING}mapping.ttl", "ttl"
+    raise HTTPException(status_code=400, detail="Invalid file type. Only .yaml, .yml, or .ttl files are accepted.")
 
 
 async def save_yaml_in_dir(yaml_path, yaml_config):
@@ -101,7 +100,8 @@ async def save_tabular_in_folder(data_tabular):
     # Read the CSV file with the detected delimiter
     df = pd.read_csv(content_str, sep=delimiter)
 
-    file_path = f"{PATH_DATA}{data_tabular.filename}"
+    safe_filename = os.path.basename(data_tabular.filename)
+    file_path = f"{PATH_DATA}{safe_filename}"
     logging.info(f"Data saved in folder {file_path}")
     df.to_csv(file_path)
 

--- a/testyarml/src/work/utils.py
+++ b/testyarml/src/work/utils.py
@@ -1,7 +1,7 @@
 import requests
 
 
-def upload_graph_db(graphdb_url, repository_id, data_file, contenttype):
+def upload_graph_db(graphdb_url, repository_id, data_file, contenttype, timeout=30):
     """
 
     @param graphdb_url:
@@ -26,7 +26,11 @@ def upload_graph_db(graphdb_url, repository_id, data_file, contenttype):
 
     # Send a POST request to upload the data to GraphDB
 
-    response = requests.post(upload_url, data=data, headers=headers)
+    try:
+        response = requests.post(upload_url, data=data, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:
+        print(f"Error connecting to GraphDB: {exc}")
+        return False
 
     # Check the response
     if response.status_code in (200, 204):


### PR DESCRIPTION
### Motivation
- Align the README endpoint documentation with the implemented FastAPI routes and clarify required form/file parameter names and examples.
- Harden runtime behavior to avoid hanging external calls and limit exposure to unsafe filenames or unsupported file types.

### Description
- Update `README.md` to document the `/generate-r2rml/`, `/load_gdb/`, and `/rdf_generation/` endpoints with matching `curl` examples and parameter descriptions.
- In `testyarml/main.py` add `timeout=60` to the `yarrrml-parser` invocation, catch `subprocess.TimeoutExpired` and return a `504` error, sanitize uploaded filenames with `os.path.basename`, validate GraphDB upload results and raise `HTTPException(status_code=502)` on failure, and remove leaking `db_str` from logs.
- In `testyarml/src/config/Initialization.py` tighten file validation to accept `.yaml`, `.yml`, or `.ttl`, return consistent `HTTPException` errors, and sanitize CSV filenames via `os.path.basename` when saving; also improve CSV delimiter sniffing fallback to comma.
- In `testyarml/src/work/utils.py` add a `timeout` parameter (default `30`) to `upload_graph_db`, pass the timeout to `requests.post`, and catch `requests.RequestException` to avoid propagating connection errors.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fef4cfe48320bccdd1dbfbd185f4)